### PR TITLE
Migrate integration to Iris API

### DIFF
--- a/custom_components/vulcan/iris/__init__.py
+++ b/custom_components/vulcan/iris/__init__.py
@@ -1,0 +1,1 @@
+from ._exceptions import *

--- a/custom_components/vulcan/iris/_exceptions.py
+++ b/custom_components/vulcan/iris/_exceptions.py
@@ -1,0 +1,70 @@
+class IrisApiException(Exception):
+    pass
+
+
+class FailedRequestException(IrisApiException):
+    pass
+
+
+class HttpUnsuccessfullStatusException(IrisApiException):
+    pass
+
+
+class ExpiredTokenException(IrisApiException):
+    pass
+
+
+class WrongPINException(IrisApiException):
+    pass
+
+
+class WrongTokenException(IrisApiException):
+    pass
+
+
+class UsedTokenException(IrisApiException):
+    pass
+
+
+class InvalidHeaderException(IrisApiException):
+    pass
+
+
+class MissingHeaderException(IrisApiException):
+    pass
+
+
+class InvalidBodyModelException(IrisApiException):
+    pass
+
+
+class InvalidSignatureException(IrisApiException):
+    pass
+
+
+class CertificateNotFoundException(IrisApiException):
+    pass
+
+
+class EntityNotFoundException(IrisApiException):
+    pass
+
+
+class ConstraintViolationException(IrisApiException):
+    pass
+
+
+class InvalidParameterValueException(IrisApiException):
+    pass
+
+
+class MissingUnitSymbolException(IrisApiException):
+    pass
+
+
+class InternalServerErrorException(IrisApiException):
+    pass
+
+
+class ResponseInvalidContentTypeException(IrisApiException):
+    pass

--- a/custom_components/vulcan/iris/_http_client.py
+++ b/custom_components/vulcan/iris/_http_client.py
@@ -1,0 +1,192 @@
+import json
+from datetime import datetime, date
+from urllib.parse import urlencode, quote
+from uuid import uuid4
+
+from aiohttp import ClientSession
+
+from iris._exceptions import (
+    CertificateNotFoundException,
+    ConstraintViolationException,
+    EntityNotFoundException,
+    ExpiredTokenException,
+    FailedRequestException,
+    HttpUnsuccessfullStatusException,
+    InternalServerErrorException,
+    InvalidBodyModelException,
+    InvalidHeaderException,
+    InvalidParameterValueException,
+    InvalidSignatureException,
+    MissingHeaderException,
+    MissingUnitSymbolException,
+    ResponseInvalidContentTypeException,
+    UsedTokenException,
+    IrisApiException,
+    WrongPINException,
+    WrongTokenException,
+)
+from iris._utils import get_encoded_path
+from iris.credentials import ICredential
+from iris.models import EnvelopeResponse
+
+USER_AGENT = "Dart/3.8 (dart:io)"
+API_VERSION = 1
+
+
+class HttpClient:
+    def __init__(
+            self,
+            credential: ICredential,
+            app_name: str,
+            app_version: str,
+            app_version_code: str,
+            session: ClientSession | None = None,
+    ):
+        self._credential = credential
+        self._app_name = app_name
+        self._app_version = app_version
+        self._app_version_code = app_version_code
+        self._owns_session = session is None
+        self._client = session or ClientSession(
+            skip_auto_headers={"Accept", "Content-Length"}
+        )
+
+    def _serialize_query(self, query: dict[str, any]):
+        datetime_format = "%Y-%m-%d %H:%M:%S"
+        date_format = "%Y-%m-%d"
+
+        stringify = {}
+        for key, value in query.items():
+            if isinstance(value, str):
+                stringify[key] = value
+            elif isinstance(value, datetime):
+                stringify[key] = value.strftime(datetime_format)
+            elif isinstance(value, date):
+                stringify[key] = value.strftime(date_format)
+            else:
+                stringify[key] = str(value)
+        return urlencode(
+            stringify,
+            quote_via=lambda s, safe, encoding=None, errors=None: quote(
+                s, safe="", encoding=encoding, errors=errors
+            ),
+        )
+
+    def _build_body(self, envelope: any):
+        now = datetime.now()
+        return json.dumps(
+            {
+                "AppName": self._app_name,
+                "AppVersion": self._app_version,
+                "NotificationToken": self._credential.notification_token or "",
+                "API": API_VERSION,
+                "RequestId": str(uuid4()),
+                "Timestamp": int(now.timestamp()),
+                "TimestampFormatted": now.strftime("%Y-%m-%d %H:%M:%S"),
+                "Envelope": envelope,
+            }
+        )
+
+    def _build_headers(self, url: str, body: str | None, pupil_id: int | None):
+        headers = {
+            "Accept-Encoding": "gzip",
+            "vOS": self._credential.device_os,
+            "vVersionCode": self._app_version_code,
+            "vAPI": str(API_VERSION),
+            "vCanonicalUrl": get_encoded_path(url),
+            "vDate": datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT"),
+            "User-Agent": USER_AGENT,
+        }
+
+        if pupil_id:
+            headers["vHint"] = str(pupil_id)
+        headers["Content-Type"] = (
+            "application/json; charset=utf-8" if body else "application/json"
+        )
+        if body:
+            headers["Content-Length"] = str(len(body))
+        headers = self._credential.sign(headers, body)
+
+        headers = {k.lower(): v for k, v in headers.items()}
+        return headers
+
+    async def request(
+            self,
+            method: str,
+            endpoint: str,
+            rest_url: str,
+            pupil_id: int | None = None,
+            query: dict[str, any] | None = None,
+            payload: any = None,
+            verify_response: bool = True
+    ):
+        url = f"{rest_url}/{endpoint}"
+        if query:
+            url += f"?{self._serialize_query(query)}"
+
+        body = self._build_body(payload) if payload else None
+        headers = self._build_headers(url, body, pupil_id)
+
+        try:
+            response = await self._client.request(
+                method=method, url=url, data=body, headers=headers
+            )
+        except Exception as exception:
+            raise FailedRequestException(exception)
+
+        if response.status != 200:
+            raise HttpUnsuccessfullStatusException(
+                f"{response.status}: {await response.text()}"
+            )
+
+        if "!DOCTYPE" in await response.text():
+            raise ResponseInvalidContentTypeException()
+
+        if verify_response:
+            response_envelope = EnvelopeResponse.model_validate(await response.json())
+            self._check_envelope_status(
+                response_envelope.status.code, response_envelope.status.message
+            )
+            return response_envelope.envelope
+
+    def _check_envelope_status(self, code: int, message: str) -> None:
+        match code:
+            case 0:
+                return
+            case -1:
+                raise InternalServerErrorException(message)
+            case 100:
+                raise InvalidSignatureException(message)
+            case 101:
+                raise InvalidBodyModelException(message)
+            case 102:
+                raise MissingHeaderException(message)
+            case 103:
+                raise InvalidHeaderException(message)
+            case 104:
+                raise MissingUnitSymbolException(message)
+            case 154:
+                raise CertificateNotFoundException(message)
+            case 200:
+                raise EntityNotFoundException(message)
+            case 201:
+                raise UsedTokenException(message)
+            case 202:
+                raise WrongTokenException(message)
+            case 203:
+                raise WrongPINException(message)
+            case 204:
+                raise ExpiredTokenException(message)
+            case 206:
+                raise InvalidParameterValueException(message)
+            case 214:
+                raise ConstraintViolationException(message)
+            case _:
+                raise IrisApiException(f"{code}: {message}")
+
+    async def close(self):
+        if self._owns_session:
+            await self._client.close()
+
+    async def __aexit__(self, *_):
+        await self.close()

--- a/custom_components/vulcan/iris/_utils.py
+++ b/custom_components/vulcan/iris/_utils.py
@@ -1,0 +1,69 @@
+import hashlib
+import re
+from urllib.parse import quote
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from iris._exceptions import WrongTokenException
+
+
+def pem_getraw(pem: bytes) -> str:
+    return pem.decode("utf-8").replace("\n", "").split("-----")[2]
+
+
+def generate_fingerprint(text: str):
+    return hashlib.md5(text.encode()).digest().hex()
+
+
+def generate_rsa_key_pair() -> tuple[str, str, str]:
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key = private_key.public_key()
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    return (
+        pem_getraw(public_pem),
+        pem_getraw(private_pem),
+        generate_fingerprint(public_pem.decode()),
+    )
+
+
+def get_encoded_path(path: str) -> str:
+    match = re.search("(api/mobile/.*)", path)
+    return quote(match[0] if match else path, safe="").lower()
+
+
+TOKEN_PREFIXES = {
+    "3S1": "https://lekcjaplus.vulcan.net.pl",
+    "TA1": "https://uonetplus-komunikacja.umt.tarnow.pl",
+    "OP1": "https://uonetplus-komunikacja.eszkola.opolskie.pl",
+    "RZ1": "https://uonetplus-komunikacja.resman.pl",
+    "GD1": "https://uonetplus-komunikacja.edu.gdansk.pl",
+    "KA1": "https://uonetplus-komunikacja.mcuw.katowice.eu",
+    "KA2": "https://uonetplus-komunikacja-test.mcuw.katowice.eu",
+    "LU1": "https://uonetplus-komunikacja.edu.lublin.eu",
+    "LU2": "https://test-uonetplus-komunikacja.edu.lublin.eu",
+    "P03": "https://efeb-komunikacja-pro-efebmobile.pro.vulcan.pl",
+    "P01": "http://efeb-komunikacja.pro-hudson.win.vulcan.pl",
+    "P02": "http://efeb-komunikacja.pro-hudsonrc.win.vulcan.pl",
+    "P90": "http://efeb-komunikacja-pro-mwujakowska.neo.win.vulcan.pl",
+    "KO1": "https://uonetplus-komunikacja.eduportal.koszalin.pl",
+}
+
+
+def get_base_url_by_token(token: str):
+    base_url = TOKEN_PREFIXES.get(token)
+    if not base_url:
+        raise WrongTokenException()
+    return base_url

--- a/custom_components/vulcan/iris/api/__init__.py
+++ b/custom_components/vulcan/iris/api/__init__.py
@@ -1,0 +1,2 @@
+from ._hebe import IrisHebeApi
+from ._hebece import IrisHebeCeApi

--- a/custom_components/vulcan/iris/api/_base.py
+++ b/custom_components/vulcan/iris/api/_base.py
@@ -1,0 +1,740 @@
+from abc import abstractmethod, ABC
+from datetime import date, datetime
+
+from iris._http_client import HttpClient
+from iris.credentials import ICredential
+from iris.models import (
+    Account,
+    Address,
+    Announcement,
+    Duty,
+    Exam,
+    Grade,
+    GradeAverage,
+    GradeSummary,
+    Homework,
+    KindergartenHours,
+    Lesson,
+    LuckyNumber,
+    MealMenu,
+    Meeting,
+    Note,
+    Message,
+    Schedule,
+    SchoolInfo,
+    PresenceMonthStats,
+    PresenceSubjectStats,
+    PushSetting,
+    Vacation,
+    UserEvent,
+    Trip,
+    Teacher,
+    Timeslot,
+)
+
+EPOCH_START_DATETIME = datetime(1970, 1, 1, 1, 0, 0)
+INT_MIN = -2_147_483_648
+DEFAULT_PAGE_SIZE = 500
+
+
+class IrisApi(ABC):
+    _http: HttpClient
+    _credential: ICredential
+
+    @abstractmethod
+    def __init__(self, credential: ICredential):
+        pass
+
+    async def get_accounts(self, pupil_id: int | None = None):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=self._credential.rest_url,
+            endpoint="mobile/register/hebe",
+            query={"mode": 2},
+            pupil_id=pupil_id,
+        )
+        return [Account.model_validate(account) for account in envelope]
+
+    async def make_heartbeat(self, rest_url: str, pupil_id: int | None = None):
+        await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            endpoint="mobile/heartbeat",
+            pupil_id=pupil_id,
+        )
+
+    async def get_addressbook(
+            self, rest_url: str, box: str, pupil_id: int | None = None
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            endpoint="mobile/addressbook",
+            query={"box": box},
+            pupil_id=pupil_id,
+        )
+        return [Address.model_validate(address) for address in envelope]
+
+    async def get_announcements(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            view: int = 6,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/announcements/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "view": view,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Announcement.model_validate(announcement) for announcement in envelope]
+
+    async def get_completed_lessons(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/lesson/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Lesson.model_validate(lesson) for lesson in envelope]
+
+    async def get_duty(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/school/duty/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Duty.model_validate(duty) for duty in envelope]
+
+    async def get_exams(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/exam/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Exam.model_validate(exam) for exam in envelope]
+
+    async def get_grades(
+            self,
+            rest_url: str,
+            unit_id: int,
+            pupil_id: int,
+            period_id: int,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/grade/byPupil",
+            query={
+                "unitId": unit_id,
+                "pupilId": pupil_id,
+                "periodId": period_id,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Grade.model_validate(grade) for grade in envelope]
+
+    async def get_grades_averages(
+            self,
+            rest_url: str,
+            unit_id: int,
+            pupil_id: int,
+            period_id: int,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/grade/average/byPupil",
+            query={
+                "unitId": unit_id,
+                "pupilId": pupil_id,
+                "periodId": period_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "scope": "auto",
+            },
+        )
+        return [GradeAverage.model_validate(average) for average in envelope]
+
+    async def get_grades_summary(
+            self,
+            rest_url: str,
+            unit_id: int,
+            pupil_id: int,
+            period_id: int,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/grade/summary/byPupil",
+            query={
+                "unitId": unit_id,
+                "pupilId": pupil_id,
+                "periodId": period_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [GradeSummary.model_validate(summary) for summary in envelope]
+
+    async def get_homework(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/homework/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Homework.model_validate(homework) for homework in envelope]
+
+    async def get_kindergarten_hours(
+            self, rest_url: str, pupil_id: int, constituent_unit_id: int
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/school/hours",
+            query={"pupilId": pupil_id, "constituentId": constituent_unit_id},
+        )
+        return KindergartenHours.model_validate(envelope)
+
+    async def get_kindergarten_teachers(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/teacher/kindergarten/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Teacher.model_validate(teacher) for teacher in envelope]
+
+    async def get_lucky_number(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            constituent_unit_id: int,
+            day: date = date.today(),
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/school/lucky",
+            query={
+                "pupilId": pupil_id,
+                "constituentId": constituent_unit_id,
+                "day": day,
+            },
+        )
+        return LuckyNumber.model_validate(envelope)
+
+    async def get_meal_menu(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            full: bool,
+            date_from: date,
+            date_to: date,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/eatery",
+            query={
+                "pupilId": pupil_id,
+                "full": full,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [MealMenu.model_validate(meal_menu) for meal_menu in envelope]
+
+    async def get_meetings(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/meetings/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "from": date_from,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Meeting.model_validate(meeting) for meeting in envelope]
+
+    async def get_notes(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/note/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Note.model_validate(note) for note in envelope]
+
+    async def get_planned_lessons(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/lesson/planned/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastSyncDate": last_sync_date,
+                "lastId": last_id,
+                "pageSize": page_size,
+            },
+        )
+        return [Lesson.model_validate(lesson) for lesson in envelope]
+
+    async def get_presence_month_stats(
+            self, rest_url: str, pupil_id: int, period_id: int
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/presence/stats/perMonth",
+            query={
+                "pupilId": pupil_id,
+                "periodId": period_id,
+            },
+        )
+        return [PresenceMonthStats.model_validate(month) for month in envelope]
+
+    async def get_presence_subject_stats(
+            self, rest_url: str, pupil_id: int, period_id: int
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/presence/stats/perSubject",
+            query={
+                "pupilId": pupil_id,
+                "periodId": period_id,
+            },
+        )
+        return [PresenceSubjectStats.model_validate(subject) for subject in envelope]
+
+    async def get_received_messages(
+            self,
+            rest_url: str,
+            box: str,
+            pupil_id: int,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/messages/received/byBox",
+            query={
+                "box": box,
+                "pupilId": pupil_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Message.model_validate(message) for message in envelope]
+
+    async def get_schedule(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/schedule/withchanges/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Schedule.model_validate(schedule) for schedule in envelope]
+
+    async def get_school_info(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/school/info",
+            query={
+                "pupilId": pupil_id,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [SchoolInfo.model_validate(school_info) for school_info in envelope]
+
+    async def get_teachers(
+            self,
+            rest_url: str,
+            period_id: int,
+            pupil_id: int,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/teacher/byPeriod",
+            query={
+                "periodId": period_id,
+                "pupilId": pupil_id,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Teacher.model_validate(teacher) for teacher in envelope]
+
+    async def get_timeslots(self, pupil_id: int | None = None):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=self._credential.rest_url,
+            endpoint="mobile/dictionary/timeslot",
+            query={"pupilId": pupil_id},
+            pupil_id=pupil_id,
+        )
+        return [Timeslot.model_validate(timeslot) for timeslot in envelope]
+
+    async def get_trips(
+            self, rest_url: str, pupil_id: int, date_from: date, date_to: date
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/trips/byPupil",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+            },
+        )
+        return [Trip.model_validate(trip) for trip in envelope]
+
+    async def get_user_events(
+            self,
+            rest_url: str,
+            pupil_id: int,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/userEvents/byPupil",
+            query={
+                "pupilId": pupil_id,
+            },
+        )
+        return [UserEvent.model_validate(user_event) for user_event in envelope]
+
+    async def get_vacations(
+            self,
+            rest_url: str,
+            pupil_id: int,
+            date_from: date,
+            date_to: date,
+            last_sync_date: datetime = EPOCH_START_DATETIME,
+            last_id: int = INT_MIN,
+            page_size: int = DEFAULT_PAGE_SIZE,
+    ):
+        envelope = await self._http.request(
+            method="GET",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            endpoint="mobile/school/vacation",
+            query={
+                "pupilId": pupil_id,
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "lastId": last_id,
+                "pageSize": page_size,
+                "lastSyncDate": last_sync_date,
+            },
+        )
+        return [Vacation.model_validate(vacation) for vacation in envelope]
+
+    async def change_message_importance(
+            self,
+            rest_url: str,
+            box_key: str,
+            message_key: str,
+            importance: bool,
+            pupil_id: int | None = None
+    ):
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/messages/importance",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            payload={
+                "BoxKey": box_key,
+                "MessageKey": message_key,
+                "Importance": importance
+            }
+        )
+
+    async def change_message_status(
+            self,
+            rest_url: str,
+            box_key: str,
+            message_key: str,
+            status: int,
+            pupil_id: int | None = None
+    ):
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/messages/status",
+            rest_url=rest_url,
+            pupil_id=pupil_id,
+            payload={
+                "BoxKey": box_key,
+                "MessageKey": message_key,
+                "Status": status
+            }
+        )
+
+    async def set_push_locale(
+            self,
+            locale: str,
+            pupil_id: int | None = None
+    ):
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/push/locale",
+            rest_url=self._credential.rest_url,
+            pupil_id=pupil_id,
+            payload=locale,
+            verify_response=False
+        )
+
+    async def set_all_push_setting(
+            self,
+            turn_on: bool,
+            pupil_id: int | None = None
+    ):
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/push/all",
+            rest_url=self._credential.rest_url,
+            pupil_id=pupil_id,
+            payload="on" if turn_on else "off"
+        )
+
+    async def set_push_setting(
+            self,
+            option: str,
+            active: bool,
+            pupil_id: int | None = None
+    ):
+        envelope = await self._http.request(
+            method="POST",
+            endpoint="mobile/push",
+            rest_url=self._credential.rest_url,
+            pupil_id=pupil_id,
+            payload={
+                "Option": option,
+                "Active": active
+            }
+        )
+        return PushSetting.model_validate(envelope)
+
+    async def configure_push(
+            self,
+            options: dict[str, bool],
+            locale: str,
+            pupil_id: int | None = None
+    ):
+        envelope_options = []
+        for name, active in options.items():
+            envelope_options.append({
+                "Option": name,
+                "Active": active
+            })
+
+        envelope = await self._http.request(
+            method="POST",
+            endpoint="mobile/push/configure",
+            rest_url=self._credential.rest_url,
+            pupil_id=pupil_id,
+            payload={
+                "Options": envelope_options,
+                "Locale": locale
+            }
+        )
+        return [PushSetting.model_validate(push) for push in envelope]
+
+    async def delete_credential(
+            self,
+            pupil_id: int | None = None
+    ):
+        await self._http.request(
+            method="DELETE",
+            endpoint="mobile/register",
+            rest_url=self._credential.rest_url,
+            pupil_id=pupil_id
+        )

--- a/custom_components/vulcan/iris/api/_hebe.py
+++ b/custom_components/vulcan/iris/api/_hebe.py
@@ -1,0 +1,42 @@
+from aiohttp import ClientSession
+
+from iris._http_client import HttpClient
+from iris._utils import get_base_url_by_token
+from iris.api._base import IrisApi
+from iris.credentials import ICredential
+
+APP_NAME = "DzienniczekPlus 2.0"
+APP_VERSION = "25.08.11 (G)"
+APP_VERSION_CODE = "756"
+
+
+class IrisHebeApi(IrisApi):
+    def __init__(self, credential: ICredential, session: ClientSession | None = None):
+        self._credential = credential
+        self._http = HttpClient(
+            credential=credential,
+            app_name=APP_NAME,
+            app_version=APP_VERSION,
+            app_version_code=APP_VERSION_CODE,
+            session=session,
+        )
+
+    async def register_by_token(self, security_token: str, pin: str, tenant: str):
+        base_url = get_base_url_by_token(security_token.upper())
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/register/token",
+            rest_url=f"{base_url}/{tenant}/api",
+            payload={
+                "OS": self._credential.device_os,
+                "Certificate": self._credential.certificate,
+                "CertificateType": self._credential.type,
+                "DeviceModel": self._credential.device_model,
+                "SelfIdentifier": self._credential.device_id,
+                "CertificateThumbprint": self._credential.fingerprint,
+                "SecurityToken": security_token.upper(),
+                "PIN": pin,
+            },
+        )
+        self._credential.rest_url = f"{base_url}/{tenant}/api"
+        return self._credential.rest_url

--- a/custom_components/vulcan/iris/api/_hebece.py
+++ b/custom_components/vulcan/iris/api/_hebece.py
@@ -1,0 +1,40 @@
+from aiohttp import ClientSession
+
+from iris._http_client import HttpClient
+from iris.api._base import IrisApi
+from iris.credentials import ICredential
+
+APP_NAME = "DzienniczekPlus 3.0"
+APP_VERSION = "25.09.24 (G)"
+APP_VERSION_CODE = "802"
+API_BASE_URL = "https://lekcjaplus.vulcan.net.pl"
+
+
+class IrisHebeCeApi(IrisApi):
+    def __init__(self, credential: ICredential, session: ClientSession | None = None):
+        self._credential = credential
+        self._http = HttpClient(
+            credential=credential,
+            app_name=APP_NAME,
+            app_version=APP_VERSION,
+            app_version_code=APP_VERSION_CODE,
+            session=session,
+        )
+
+    async def register_by_jwt(self, tokens: list[str], tenant: str):
+        await self._http.request(
+            method="POST",
+            endpoint="mobile/register/jwt",
+            rest_url=f"{API_BASE_URL}/{tenant}/api",
+            payload={
+                "OS": self._credential.device_os,
+                "Certificate": self._credential.certificate,
+                "CertificateType": self._credential.type,
+                "DeviceModel": self._credential.device_model,
+                "SelfIdentifier": self._credential.device_id,
+                "CertificateThumbprint": self._credential.fingerprint,
+                "Tokens": tokens,
+            },
+        )
+        self._credential.rest_url = f"{API_BASE_URL}/{tenant}/api"
+        return self._credential.rest_url

--- a/custom_components/vulcan/iris/credentials/__init__.py
+++ b/custom_components/vulcan/iris/credentials/__init__.py
@@ -1,0 +1,2 @@
+from ._icredential import ICredential
+from ._rsa_credential import RsaCredential

--- a/custom_components/vulcan/iris/credentials/_icredential.py
+++ b/custom_components/vulcan/iris/credentials/_icredential.py
@@ -1,0 +1,27 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ICredential(BaseModel):
+    type: str
+    rest_url: str | None
+    certificate: str
+    private_key: str | None
+    fingerprint: str
+    notification_token: str | None
+    device_id: str
+    device_os: Literal["Android", "iOS"]
+    device_model: str
+
+    @staticmethod
+    def create_new(
+            device_os: Literal["Android", "iOS"],
+            device_model: str,
+            rest_url: str | None,
+            notification_token: str | None = None,
+    ) -> "ICredential":
+        pass
+
+    def sign(self, headers: dict[str, str], body: str | None) -> dict[str, str]:
+        pass

--- a/custom_components/vulcan/iris/credentials/_rsa_credential.py
+++ b/custom_components/vulcan/iris/credentials/_rsa_credential.py
@@ -1,0 +1,80 @@
+import hashlib
+from base64 import b64decode, b64encode
+from typing import Literal
+from uuid import uuid4
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+from iris._utils import generate_rsa_key_pair
+from iris.credentials._icredential import ICredential
+
+
+class RsaCredential(ICredential):
+    @staticmethod
+    def create_new(
+            device_os: Literal["Android", "iOS"],
+            device_model: str,
+            rest_url: str | None = None,
+            notification_token: str | None = None,
+    ) -> "RsaCredential":
+        certificate, private_key, fingerprint = generate_rsa_key_pair()
+
+        return RsaCredential(
+            type="RSA_PEM",
+            rest_url=rest_url,
+            certificate=certificate,
+            private_key=private_key,
+            fingerprint=fingerprint,
+            notification_token=notification_token,
+            device_id=str(uuid4()),
+            device_os=device_os,
+            device_model=device_model,
+        )
+
+    def sign(self, headers: dict[str, str], body: str | None) -> dict[str, str]:
+        private_key: RSAPrivateKey = serialization.load_der_private_key(
+            b64decode(self.private_key), password=None, backend=default_backend()
+        )
+
+        if body is not None:
+            headers["Digest"] = self._get_digest(body)
+
+        signature_header_names = (
+            ["vCanonicalUrl", "Digest", "vDate"]
+            if body is not None
+            else ["vCanonicalUrl", "vDate"]
+        )
+        signature_headers = {k: headers[k] for k in signature_header_names}
+
+        headers["Signature"] = self._get_signature_header(
+            signature_headers, private_key, self.fingerprint
+        )
+
+        if "Digest" in headers:
+            headers["Digest"] = f"SHA-256={headers["Digest"]}"
+
+        return headers
+
+    def _get_digest(self, body: str) -> str:
+        return b64encode(hashlib.sha256(body.encode()).digest()).decode()
+
+    def _get_signature_header(
+            self, headers: dict[str, str], private_key: RSAPrivateKey, fingerprint: str
+    ) -> str:
+        header_names = " ".join(headers.keys())
+        header_values = "".join(headers.values())
+
+        signature = private_key.sign(
+            header_values.encode(), padding.PKCS1v15(), hashes.SHA256()
+        )
+        signature_b64 = b64encode(signature).decode()
+
+        return (
+            f'keyId="{fingerprint}",'
+            f'headers="{header_names}",'
+            f'algorithm="sha256withrsa",'
+            f"signature=Base64(SHA256withRSA({signature_b64}))"
+        )

--- a/custom_components/vulcan/iris/models/__init__.py
+++ b/custom_components/vulcan/iris/models/__init__.py
@@ -1,0 +1,44 @@
+from ._account import (
+    Account,
+    AccountLinks,
+    Address,
+    ConstituentUnit,
+    Constraints,
+    Journal,
+    MessageBox,
+    Period,
+    Pupil,
+    Unit,
+)
+from ._addressbook import Address
+from ._announcement import Announcement
+from ._attachment import Attachment
+from ._clazz import Clazz
+from ._distribution import Distribution
+from ._duty import Duty
+from ._employee import Employee
+from ._envelope_response import EnvelopeResponse
+from ._exam import Exam
+from ._grade import Grade, GradeCategory, GradeColumn
+from ._grade_average import GradeAverage
+from ._grade_summary import GradeSummary
+from ._homework import Homework
+from ._kindergarten_hours import KindergartenHours
+from ._lesson import Lesson, PresenceType
+from ._lucky_number import LuckyNumber
+from ._meal_menu import MealMenu, MealMenuEntry
+from ._meeting import Meeting
+from ._message import Message, MessageAddress, MessageAddressExtras
+from ._note import Note, NoteCategory
+from ._presence_month_stats import PresenceMonthStats
+from ._presence_subject_stats import PresenceSubjectStats
+from ._push_setting import PushSetting
+from ._room import Room
+from ._schedule import Schedule, ScheduleChange, ScheduleSubstitution
+from ._school_info import SchoolInfo
+from ._subject import Subject
+from ._teacher import Teacher
+from ._timeslot import Timeslot
+from ._trip import Trip
+from ._user_event import UserEvent
+from ._vacation import Vacation

--- a/custom_components/vulcan/iris/models/_account.py
+++ b/custom_components/vulcan/iris/models/_account.py
@@ -1,0 +1,101 @@
+from datetime import date, time
+
+from pydantic import BaseModel, Field
+
+from iris.models._addressbook import Address
+
+
+class AccountLinks(BaseModel):
+    root: str = Field(alias="Root")
+    group: str = Field(alias="Group")
+    symbol: str = Field(alias="Symbol")
+    alias: str | None = Field(alias="Alias")
+    questionnaire_root: str = Field(alias="QuestionnaireRoot")
+    ex_resources_url: str = Field(alias="ExResourcesUrl")
+
+
+class Unit(BaseModel):
+    id: int = Field(alias="Id")
+    symbol: str = Field(alias="Symbol")
+    short: str = Field(alias="Short")
+    rest_url: str = Field(alias="RestURL")
+    name: str = Field(alias="Name")
+    address: str | None = Field(alias="Address")
+    patron: str | None = Field(alias="Patron")
+    display_name: str = Field(alias="DisplayName")
+    school_topic: str = Field(alias="SchoolTopic")
+
+
+class ConstituentUnit(BaseModel):
+    id: int = Field(alias="Id")
+    short: str = Field(alias="Short")
+    name: str = Field(alias="Name")
+    address: str | None = Field(alias="Address")
+    patron: str | None = Field(alias="Patron")
+    school_topic: str = Field(alias="SchoolTopic")
+
+
+class Pupil(BaseModel):
+    id: int = Field(alias="Id")
+    login_id: int = Field(alias="LoginId")
+    first_name: str = Field(alias="FirstName")
+    second_name: str = Field(alias="SecondName")
+    surname: str = Field(alias="Surname")
+    sex: bool = Field(alias="Sex")
+
+
+class Period(BaseModel):
+    capabilites: list[str] = Field(alias="Capabilities")
+    id: int = Field(alias="Id")
+    level: int = Field(alias="Level")
+    number: int = Field(alias="Number")
+    start: date = Field(alias="StartAt")
+    end: date = Field(alias="EndAt")
+    current: bool = Field(alias="Current")
+    last: bool = Field(alias="Last")
+
+
+class Journal(BaseModel):
+    id: int = Field(alias="Id")
+    start: date = Field(alias="StartAt")
+    end: date = Field(alias="EndAt")
+    pupil_number: int = Field(alias="PupilNumber")
+
+
+class Constraints(BaseModel):
+    absence_days_before: int = Field(alias="AbsenceDaysBefore")
+    absence_hours_before: time = Field(alias="AbsenceHoursBefore")
+    presence_blocade: any = Field(alias="PresenceBlocade")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class MessageBox(BaseModel):
+    id: int = Field(alias="Id")
+    global_key: str = Field(alias="GlobalKey")
+    name: str = Field(alias="Name")
+
+
+class Account(BaseModel):
+    top_level_partition: str = Field(alias="TopLevelPartition")
+    partition: str = Field(alias="Partition")
+    links: AccountLinks = Field(alias="Links")
+    class_display: str | None = Field(alias="ClassDisplay")
+    info_display: str | None = Field(alias="InfoDisplay")
+    login: any = Field(alias="Login")
+    unit: Unit = Field(alias="Unit")
+    constituent_unit: ConstituentUnit = Field(alias="ConstituentUnit")
+    capabilities: list[str] = Field(alias="Capabilities")
+    educators_list: list[Address] = Field(alias="EducatorsList")
+    pupil: Pupil = Field(alias="Pupil")
+    caretaker_id: int | None = Field(alias="CaretakerId")
+    periods: list[Period] = Field(alias="Periods")
+    journal: Journal | None = Field(alias="Journal")
+    constraints: Constraints = Field(alias="Constraints")
+    state: int = Field(alias="State")
+    message_box: MessageBox | None = Field(alias="MessageBox")
+    profile_id: str | None = Field(alias="ProfileId")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_addressbook.py
+++ b/custom_components/vulcan/iris/models/_addressbook.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, Field
+
+
+class Address(BaseModel):
+    global_key: str = Field(alias="GlobalKey")
+    name: str = Field(alias="Name")
+    group: str | None = Field(alias="Group")

--- a/custom_components/vulcan/iris/models/_announcement.py
+++ b/custom_components/vulcan/iris/models/_announcement.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._attachment import Attachment
+from iris.models._employee import Employee
+
+
+class Announcement(BaseModel):
+    id: int = Field(alias="Id")
+    unit_id: int = Field(alias="IdUnit")
+    title: str = Field(alias="Title")
+    content: str = Field(alias="Content")
+    category: str | None = Field(alias="Category")
+    date_from: date = Field(alias="From")
+    date_to: date = Field(alias="To")
+    sender: Employee = Field(alias="Sender")
+    attachments: list[Attachment] = Field(alias="Attachments")
+    created_at: datetime = Field(alias="CreatedAt")
+    modified_at: datetime = Field(alias="ModifiedAt")

--- a/custom_components/vulcan/iris/models/_attachment.py
+++ b/custom_components/vulcan/iris/models/_attachment.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class Attachment(BaseModel):
+    name: str = Field(alias="Name")
+    link: str = Field(alias="Link")

--- a/custom_components/vulcan/iris/models/_clazz.py
+++ b/custom_components/vulcan/iris/models/_clazz.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class Clazz(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    display_name: str = Field(alias="DisplayName")
+    symbol: str = Field(alias="Symbol")

--- a/custom_components/vulcan/iris/models/_distribution.py
+++ b/custom_components/vulcan/iris/models/_distribution.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+
+
+class Distribution(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    shortcut: str = Field(alias="Shortcut")
+    name: str = Field(alias="Name")
+    part_type: str = Field(alias="PartType")

--- a/custom_components/vulcan/iris/models/_duty.py
+++ b/custom_components/vulcan/iris/models/_duty.py
@@ -1,0 +1,12 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+
+class Duty(BaseModel):
+    id: int = Field(alias="Id")
+    unit_id: int = Field(alias="UnitId")
+    journal_id: int = Field(alias="JournalId")
+    pupil_id: int = Field(alias="PupilId")
+    date_: date = Field(alias="DateAt")
+    modified_at: datetime = Field(alias="ModifiedAt")

--- a/custom_components/vulcan/iris/models/_employee.py
+++ b/custom_components/vulcan/iris/models/_employee.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class Employee(BaseModel):
+    id: int = Field(alias="Id")
+    surname: str = Field(alias="Surname")
+    name: str = Field(alias="Name")
+    display_name: str = Field(alias="DisplayName")

--- a/custom_components/vulcan/iris/models/_envelope_response.py
+++ b/custom_components/vulcan/iris/models/_envelope_response.py
@@ -1,0 +1,20 @@
+from typing import Union
+
+from pydantic import BaseModel, Field
+
+
+class ApiStatus(BaseModel):
+    code: int = Field(alias="Code")
+    message: str = Field(alias="Message")
+
+
+class EnvelopeResponse(BaseModel):
+    envelope_type: str = Field(alias="EnvelopeType")
+    envelope: any = Field(alias="Envelope")
+    status: ApiStatus = Field(alias="Status")
+    request_id: str = Field(alias="RequestId")
+    timestamp: Union[float, int] = Field(alias="Timestamp")
+    timestamp_formatted: str = Field(alias="TimestampFormatted")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_exam.py
+++ b/custom_components/vulcan/iris/models/_exam.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._employee import Employee
+from iris.models._subject import Subject
+
+
+class Exam(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    type: str = Field(alias="Type")
+    type_id: int = Field(alias="TypeId")
+    content: str = Field(alias="Content")
+    created_at: datetime = Field(alias="CreatedAt")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    deadline: datetime = Field(alias="DeadlineAt")
+    creator: Employee = Field(alias="Creator")
+    subject: Subject = Field(alias="Subject")
+    pupil_id: int = Field(alias="PupilId")
+    didactics: any = Field(alias="Didactics")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_grade.py
+++ b/custom_components/vulcan/iris/models/_grade.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._employee import Employee
+from iris.models._subject import Subject
+
+
+class GradeCategory(BaseModel):
+    id: int = Field(alias="Id")
+    name: str = Field(alias="Name")
+    code: str = Field(alias="Code")
+
+
+class GradeColumn(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    period_id: int = Field(alias="PeriodId")
+    name: str = Field(alias="Name")
+    code: str = Field(alias="Code")
+    group: str = Field(alias="Group")
+    number: int = Field(alias="Number")
+    color: int = Field(alias="Color")
+    weight: float = Field(alias="Weight")
+    subject: Subject = Field(alias="Subject")
+    category: GradeCategory | None = Field(alias="Category")
+
+
+class Grade(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    pupil_id: int = Field(alias="PupilId")
+    content_raw: str = Field(alias="ContentRaw")
+    content: str = Field(alias="Content")
+    comment: str = Field(alias="Comment")
+    value: float | None = Field(alias="Value")
+    numerator: int | None = Field(alias="Numerator")
+    denominator: int | None = Field(alias="Denominator")
+    created_at: datetime = Field(alias="CreatedAt")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    creator: Employee = Field(alias="Creator")
+    modifier: Employee = Field(alias="Modifier")
+    column: GradeColumn = Field(alias="Column")
+    corrected_grade: str | None = Field(alias="CorrectedGrade")

--- a/custom_components/vulcan/iris/models/_grade_average.py
+++ b/custom_components/vulcan/iris/models/_grade_average.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+
+from iris.models._subject import Subject
+
+
+class GradeAverage(BaseModel):
+    id: int = Field(alias="Id")
+    pupil_id: int = Field(alias="PupilId")
+    period_id: int = Field(alias="PupilId")
+    subject: Subject = Field(alias="Subject")
+    average: str | None = Field(alias="Average")
+    points: str | None = Field(alias="Points")
+    annotation: any = Field(alias="Annotation")
+    scope: str = Field(alias="Scope")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_grade_summary.py
+++ b/custom_components/vulcan/iris/models/_grade_summary.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._subject import Subject
+
+
+class GradeSummary(BaseModel):
+    id: int = Field(alias="Id")
+    pupil_id: int = Field(alias="PupilId")
+    period_id: int = Field(alias="PeriodId")
+    subject: Subject = Field(alias="Subject")
+    entry_1: str | None = Field(alias="Entry_1")
+    entry_2: str | None = Field(alias="Entry_2")
+    entry_3: str | None = Field(alias="Entry_3")
+    modified_at: datetime | None = Field(alias="ModifiedAt")

--- a/custom_components/vulcan/iris/models/_homework.py
+++ b/custom_components/vulcan/iris/models/_homework.py
@@ -1,0 +1,28 @@
+from datetime import datetime, date
+
+from pydantic import BaseModel, Field
+
+from iris.models._attachment import Attachment
+from iris.models._employee import Employee
+from iris.models._subject import Subject
+
+
+class Homework(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    id_pupil: int = Field(alias="IdPupil")
+    id_homework: int = Field(alias="IdHomework")
+    content: str = Field(alias="Content")
+    is_answer_required: bool = Field(alias="IsAnswerRequired")
+    created_at: datetime = Field(alias="CreatedAt")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    date_: date = Field(alias="DateAt")
+    answer_at: datetime | None = Field(alias="AnswerAt")
+    deadline: date = Field(alias="DeadlineAt")
+    creator: Employee = Field(alias="Creator")
+    subject: Subject = Field(alias="Subject")
+    attachments: list[Attachment] = Field(alias="Attachments")
+    didactics: any = Field(alias="Didactics")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_kindergarten_hours.py
+++ b/custom_components/vulcan/iris/models/_kindergarten_hours.py
@@ -1,0 +1,9 @@
+from datetime import time
+
+from pydantic import BaseModel, Field
+
+
+class KindergartenHours(BaseModel):
+    constituent_unit_id: int = Field(alias="Id")
+    hour_from: time = Field(alias="HourFrom")
+    hour_to: time = Field(alias="HourTo")

--- a/custom_components/vulcan/iris/models/_lesson.py
+++ b/custom_components/vulcan/iris/models/_lesson.py
@@ -1,0 +1,56 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._clazz import Clazz
+from iris.models._distribution import Distribution
+from iris.models._employee import Employee
+from iris.models._subject import Subject
+from iris.models._timeslot import Timeslot
+
+
+class PresenceType(BaseModel):
+    id: int = Field(alias="Id")
+    symbol: str = Field(alias="Symbol")
+    name: str = Field(alias="Name")
+    category_id: int = Field(alias="CategoryId")
+    category_name: str = Field(alias="CategoryName")
+    position: int = Field(alias="Position")
+    presence: bool = Field(alias="Presence")
+    absence: bool = Field(alias="Absence")
+    legal_absence: bool = Field(alias="LegalAbsence")
+    late: bool = Field(alias="Late")
+    absence_justified: bool = Field(alias="AbsenceJustified")
+    removed: bool = Field(alias="Removed")
+
+
+class Lesson(BaseModel):
+    lesson_id: int = Field(alias="LessonId")
+    presence_type: PresenceType | None = Field(alias="PresenceType")
+    collection: list[any] = Field(alias="Collection")
+    justification_status: int | None = Field(alias="JustificationStatus")
+    id: int = Field(alias="Id")
+    lesson_class_id: int = Field(alias="LessonClassId")
+    day: date = Field(alias="DayAt")
+    calculate_presence: bool = Field(alias="CalculatePresence")
+    group_definition: str | None = Field(alias="GroupDefinition")
+    public_resources: str | None = Field(alias="PublicResources")
+    remote_resources: str | None = Field(alias="RemoteResources")
+    replacement: bool = Field(alias="Replacement")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    global_key: str = Field(alias="GlobalKey")
+    note: str | None = Field(alias="Note")
+    topic: str | None = Field(alias="Topic")
+    lesson_number: int | None = Field(alias="LessonNumber")
+    lesson_class_global_key: str = Field(alias="LessonClassGlobalKey")
+    time_slot: Timeslot = Field(alias="TimeSlot")
+    subject: Subject | None = Field(alias="Subject")
+    teacher_primary: Employee = Field(alias="TeacherPrimary")
+    teacher_secondary: Employee | None = Field(alias="TeacherSecondary")
+    teacher_mod: Employee = Field(alias="TeacherMod")
+    clazz: Clazz = Field(alias="Clazz")
+    distirbution: Distribution | None = Field(alias="Distribution")
+    didactics: any = Field(alias="Didactics")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_lucky_number.py
+++ b/custom_components/vulcan/iris/models/_lucky_number.py
@@ -1,0 +1,8 @@
+from datetime import date
+
+from pydantic import BaseModel, Field
+
+
+class LuckyNumber(BaseModel):
+    day: date = Field(alias="Day")
+    number: int = Field(alias="Number")

--- a/custom_components/vulcan/iris/models/_meal_menu.py
+++ b/custom_components/vulcan/iris/models/_meal_menu.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class MealMenuEntry(BaseModel):
+    name: str = Field(alias="Name")
+    metadata: any = Field(alias="Metadata")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class MealMenu(BaseModel):
+    inner_id: int = Field(alias="InnerId")
+    id: int = Field(alias="Id")
+    diet_name: str = Field(alias="DietName")
+    meal_name: str = Field(alias="MealName")
+    dishes: str = Field(alias="Dishes")
+    metadata: any = Field(alias="Metadata")
+    entries: list[MealMenuEntry] = Field(alias="Entires")
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/custom_components/vulcan/iris/models/_meeting.py
+++ b/custom_components/vulcan/iris/models/_meeting.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class Meeting(BaseModel):
+    id: int = Field(alias="Id")
+    when: datetime = Field(alias="DateAt")
+    where: str = Field(alias="Where")
+    why: str = Field(alias="Why")
+    agenda: str = Field(alias="Agenda")
+    additional_info: str | None = Field(alias="AdditionalInfo")
+    online: str = Field(alias="Online")
+    created_at: datetime = Field(alias="CreatedAt")
+    modified_at: datetime = Field(alias="ModifiedAt")

--- a/custom_components/vulcan/iris/models/_message.py
+++ b/custom_components/vulcan/iris/models/_message.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._attachment import Attachment
+
+
+class MessageAddressExtras(BaseModel):
+    displayed_class: str = Field(alias="DisplayedClass")
+
+
+class MessageAddress(BaseModel):
+    global_key: str = Field(alias="GlobalKey")
+    name: str = Field(alias="Name")
+    has_read: bool | None = Field(alias="HasRead")
+    extras: MessageAddressExtras | None = Field(alias="Extras")
+
+
+class Message(BaseModel):
+    id: str = Field(alias="Id")
+    global_key: str = Field(alias="GlobalKey")
+    thread_key: str = Field(alias="ThreadKey")
+    subject: str = Field(alias="Subject")
+    content: str = Field(alias="Content")
+    sent_at: datetime = Field(alias="SentAt")
+    read_at: datetime | None = Field(alias="ReadAt")
+    status: int = Field(alias="Status")
+    sender: MessageAddress = Field(alias="Sender")
+    receiver: list[MessageAddress] = Field(alias="Receiver")
+    attachments: list[Attachment] = Field(alias="Attachments")
+    # importance: int | None = Field(alis="Importance")
+    widthdrawn: bool = Field(alias="Withdrawn")

--- a/custom_components/vulcan/iris/models/_note.py
+++ b/custom_components/vulcan/iris/models/_note.py
@@ -1,0 +1,25 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._employee import Employee
+
+
+class NoteCategory(BaseModel):
+    id: int = Field(alias="Id")
+    name: str = Field(alias="Name")
+    type: str | None = Field(alias="Type")
+    default_points: int | None = Field(alias="DefaultPoints")
+
+
+class Note(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    id_pupil: int = Field(alias="IdPupil")
+    positive: bool = Field(alias="Positive")
+    date_valid: date = Field(alias="ValidAt")
+    date_modify: datetime = Field(alias="ModifiedAt")
+    creator: Employee = Field(alias="Creator")
+    category: NoteCategory | None = Field(alias="Category")
+    content: str = Field(alias="Content")
+    points: int | None = Field(alias="Points")

--- a/custom_components/vulcan/iris/models/_presence_month_stats.py
+++ b/custom_components/vulcan/iris/models/_presence_month_stats.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+
+
+class PresenceMonthStats(BaseModel):
+    period_id: int = Field(alias="PeriodId")
+    month: int = Field(alias="Month")
+    presence_percentage: float = Field(alias="PresencePercentage")
+    absences: int = Field(alias="Absences")
+    absences_justified: int = Field(alias="AbsencesJustified")
+    late_arrivals: int = Field(alias="LateArrivals")
+    late_arrivals_justified: int = Field(alias="LateArrivalsJustified")
+    exemptions: int = Field(alias="Exemptions")
+    absences_due_to_school: int = Field(alias="AbsencesDueToSchool")

--- a/custom_components/vulcan/iris/models/_presence_subject_stats.py
+++ b/custom_components/vulcan/iris/models/_presence_subject_stats.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+
+class PresenceSubjectStats(BaseModel):
+    period_id: int = Field(alias="PeriodId")
+    subject_id: int = Field(alias="SubjectId")
+    subject_name: str = Field(alias="SubjectName")
+    presence_percentage: float = Field(alias="PresencePercentage")
+    absences: int = Field(alias="Absences")
+    absences_justified: int = Field(alias="AbsencesJustified")
+    late_arrivals: int = Field(alias="LateArrivals")
+    late_arrivals_justified: int = Field(alias="LateArrivalsJustified")
+    exemptions: int = Field(alias="Exemptions")
+    absences_due_to_school: int = Field(alias="AbsencesDueToSchool")

--- a/custom_components/vulcan/iris/models/_push_setting.py
+++ b/custom_components/vulcan/iris/models/_push_setting.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class PushSetting(BaseModel):
+    id: int = Field(alias="Id")
+    mobile_certificate_id: int = Field(alias="MobileCertyfikatId")
+    option: str = Field(alias="Option")
+    active: bool = Field(alias="Active")

--- a/custom_components/vulcan/iris/models/_room.py
+++ b/custom_components/vulcan/iris/models/_room.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class Room(BaseModel):
+    id: int = Field(alias="Id")
+    code: str = Field(alias="Code")

--- a/custom_components/vulcan/iris/models/_schedule.py
+++ b/custom_components/vulcan/iris/models/_schedule.py
@@ -1,0 +1,73 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+from iris.models._clazz import Clazz
+from iris.models._distribution import Distribution
+from iris.models._employee import Employee
+from iris.models._room import Room
+from iris.models._subject import Subject
+from iris.models._timeslot import Timeslot
+
+
+class ScheduleChange(BaseModel):
+    id: int = Field(alias="Id")
+    type: int = Field(alias="Type")
+    is_merge: bool = Field(alias="IsMerge")
+    separation: bool = Field(alias="Separation")
+
+
+class ScheduleSubstitution(BaseModel):
+    id: int = Field(alias="Id")
+    unit_id: int = Field(alias="UnitId")
+    schedule_id: int = Field(alias="ScheduleId")
+    date_: date = Field(alias="DateAt")
+    change_date: date | None = Field(alias="ChangeDateAt")
+    pupil_note: str | None = Field(alias="PupilNote")
+    reason: str | None = Field(alias="Reason")
+    event: str | None = Field(alias="Event")
+    room: Room | None = Field(alias="Room")
+    time_slot: Timeslot | None = Field(alias="TimeSlot")
+    subject: Subject | None = Field(alias="Subject")
+    teacher_primary: Employee | None = Field(alias="TeacherPrimary")
+    teacher_absence_reason_id: int | None = Field(alias="TeacherAbsenceReasonId")
+    teacher_absence_effect_name: str | None = Field(alias="TeacherAbsenceEffectName")
+    teacher_secondary: Employee | None = Field(alias="TeacherSecondary")
+    teacher_secondary_absence_reason_id: int | None = Field(
+        alias="TeacherSecondaryAbsenceReasonId"
+    )
+    teacher_secondary_absence_effect_name: str | None = Field(
+        alias="TeacherSecondaryAbsenceEffectName"
+    )
+    teacher_secondary2: Employee | None = Field(alias="TeacherSecondary2")
+    teacher_secondary_absence_reason_id: int | None = Field(
+        alias="TeacherSecondary2AbsenceReasonId"
+    )
+    teacher_secondary_absence_effect_name: str | None = Field(
+        alias="TeacherSecondary2AbsenceEffectName"
+    )
+    change: ScheduleChange | None = Field(alias="Change")
+    clazz: Clazz | None = Field(alias="Clazz")
+    distribution: Distribution | None = Field(alias="Distribution")
+    class_absence: bool = Field(alias="ClassAbsence")
+    no_room: bool = Field(alias="NoRoom")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    description: str | None = Field(alias="Description")
+
+
+class Schedule(BaseModel):
+    id: int = Field(alias="Id")
+    merge_change_id: int | None = Field(alias="MergeChangeId")
+    event: str | None = Field(alias="Event")
+    date_: date = Field(alias="DateAt")
+    room: Room | None = Field(alias="Room")
+    time_slot: Timeslot = Field(alias="TimeSlot")
+    subject: Subject | None = Field(alias="Subject")
+    teacher_primary: Employee | None = Field(alias="TeacherPrimary")
+    teacher_secondary: Employee | None = Field(alias="TeacherSecondary")
+    teacher_secondary2: Employee | None = Field(alias="TeacherSecondary2")
+    clazz: Clazz = Field(alias="Clazz")
+    distribution: Distribution | None = Field(alias="Distribution")
+    pupil_alias: str | None = Field(alias="PupilAlias")
+    substitution: ScheduleSubstitution | None = Field(alias="Substitution")
+    parent: str | None = Field(alias="Parent")

--- a/custom_components/vulcan/iris/models/_school_info.py
+++ b/custom_components/vulcan/iris/models/_school_info.py
@@ -1,0 +1,13 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+
+class SchoolInfo(BaseModel):
+    id: int = Field(alias="Id")
+    unit_id: int = Field(alias="UnitId")
+    date_: date = Field(alias="DateAt")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    availability: int = Field(alias="Availability")
+    topic: str = Field(alias="Topic")
+    content: str = Field(alias="Content")

--- a/custom_components/vulcan/iris/models/_subject.py
+++ b/custom_components/vulcan/iris/models/_subject.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+
+
+class Subject(BaseModel):
+    id: int = Field(alias="Id")
+    key: str = Field(alias="Key")
+    name: str = Field(alias="Name")
+    code: str = Field(alias="Kod")
+    position: int = Field(alias="Position")

--- a/custom_components/vulcan/iris/models/_teacher.py
+++ b/custom_components/vulcan/iris/models/_teacher.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+
+class Teacher(BaseModel):
+    description: str = Field(alias="Description")
+    position: int = Field(alias="Position")
+    box_id: str = Field(alias="BoxId")
+    id: int = Field(alias="Id")
+    surname: str | None = Field(alias="Surname")
+    name: str | None = Field(alias="Name")
+    display_name: str = Field(alias="DisplayName")

--- a/custom_components/vulcan/iris/models/_timeslot.py
+++ b/custom_components/vulcan/iris/models/_timeslot.py
@@ -1,0 +1,11 @@
+from datetime import time
+
+from pydantic import BaseModel, Field
+
+
+class Timeslot(BaseModel):
+    id: int = Field(alias="Id")
+    start: time = Field(alias="Start")
+    end: time = Field(alias="End")
+    display: str = Field(alias="Display")
+    position: int = Field(alias="Position")

--- a/custom_components/vulcan/iris/models/_trip.py
+++ b/custom_components/vulcan/iris/models/_trip.py
@@ -1,0 +1,19 @@
+from datetime import date
+
+from pydantic import BaseModel, Field
+
+from iris.models._timeslot import Timeslot
+
+
+class Trip(BaseModel):
+    id: int = Field(alias="Id")
+    trip_id: int = Field(alias="TripId")
+    date_from: date = Field(alias="From")
+    date_to: date = Field(alias="To")
+    description: str = Field(alias="Description")
+    supervisor: str = Field(alias="Supervisor")
+    goal: str = Field(alias="Goal")
+    route: str = Field(alias="Route")
+    transport: str = Field(alias="Transport")
+    start_timeslot: Timeslot | None = Field(alias="StartTimeslot")
+    end_timeslot: Timeslot | None = Field(alias="EndTimeslot")

--- a/custom_components/vulcan/iris/models/_user_event.py
+++ b/custom_components/vulcan/iris/models/_user_event.py
@@ -1,0 +1,18 @@
+from datetime import date, datetime, time
+
+from pydantic import BaseModel, Field
+
+
+class UserEvent(BaseModel):
+    id: int = Field(alias="Id")
+    pupil_id: int = Field(alias="PupilId")
+    name: str = Field(alias="Name")
+    description: str | None = Field(alias="Description")
+    display_mode: int = Field(alias="DisplayMode")
+    date_: date = Field(alias="DateAt")
+    modified_at: datetime = Field(alias="ModifiedAt")
+    start_time: time = Field(alias="StartTime")
+    end_time: time = Field(alias="EndTime")
+    repeat_mode: int = Field(alias="RepeatMode")
+    end_at: datetime | None = Field(alias="EndAt")
+    is_owner: bool = Field(alias="IsOwner")

--- a/custom_components/vulcan/iris/models/_vacation.py
+++ b/custom_components/vulcan/iris/models/_vacation.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from pydantic import BaseModel, Field
+
+
+class Vacation(BaseModel):
+    id: int = Field(alias="Id")
+    name: str = Field(alias="Name")
+    date_from: date = Field(alias="From")
+    date_to: date = Field(alias="To")

--- a/custom_components/vulcan/iris_client.py
+++ b/custom_components/vulcan/iris_client.py
@@ -1,0 +1,180 @@
+"""Helper client adapting the Iris API to the integration needs."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from aiohttp import ClientSession
+
+from .iris.api import IrisHebeApi
+from .iris.credentials import RsaCredential
+from .iris.models import Account, Period
+
+
+class IrisClient:
+    """Wrap the Iris API and expose convenience helpers used by the integration."""
+
+    def __init__(self, credential: RsaCredential, session: ClientSession) -> None:
+        self._credential = credential
+        self._session = session
+        self._api = IrisHebeApi(credential, session=session)
+        self.account: Account | None = None
+
+    @property
+    def credential(self) -> RsaCredential:
+        """Return credential data."""
+
+        return self._credential
+
+    async def get_students(self) -> list[Account]:
+        """Return the list of students available for this credential."""
+
+        return await self._api.get_accounts()
+
+    async def select_student(self, student_id: str) -> None:
+        """Select the active student by identifier."""
+
+        for account in await self.get_students():
+            if str(account.pupil.id) == str(student_id):
+                self.account = account
+                return
+        raise ValueError(f"Student {student_id} not found")
+
+    @property
+    def student(self) -> Account:
+        """Return the currently selected student."""
+
+        if self.account is None:
+            raise RuntimeError("Student has not been selected")
+        return self.account
+
+    @property
+    def rest_url(self) -> str:
+        return self.student.unit.rest_url
+
+    @property
+    def pupil_id(self) -> int:
+        return self.student.pupil.id
+
+    @property
+    def unit_id(self) -> int:
+        return self.student.unit.id
+
+    @property
+    def constituent_unit_id(self) -> int:
+        return self.student.constituent_unit.id
+
+    @property
+    def message_box_key(self) -> str | None:
+        return self.student.message_box.global_key if self.student.message_box else None
+
+    def _current_period(self) -> Period:
+        for period in self.student.periods:
+            if period.current or period.last:
+                return period
+        return self.student.periods[-1]
+
+    @property
+    def current_period_id(self) -> int:
+        return self._current_period().id
+
+    @property
+    def api(self) -> IrisHebeApi:
+        return self._api
+
+    async def get_schedule(self, date_from: date | None, date_to: date | None):
+        if date_from is None:
+            date_from = date.today()
+        if date_to is None:
+            date_to = date_from
+        return await self._api.get_schedule(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def get_homework(self):
+        return await self._api.get_homework(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date.today(),
+            date_to=date.today(),
+        )
+
+    async def get_exams(self):
+        return await self._api.get_exams(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date.today(),
+            date_to=date.today(),
+        )
+
+    async def get_grades(self):
+        return await self._api.get_grades(
+            rest_url=self.rest_url,
+            unit_id=self.unit_id,
+            pupil_id=self.pupil_id,
+            period_id=self.current_period_id,
+        )
+
+    async def get_completed_lessons(self, date_from: date | None = None, date_to: date | None = None):
+        if date_from is None:
+            date_from = date.today()
+        if date_to is None:
+            date_to = date_from
+        return await self._api.get_completed_lessons(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def get_homework_range(self, date_from: date, date_to: date):
+        return await self._api.get_homework(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def get_exams_range(self, date_from: date, date_to: date):
+        return await self._api.get_exams(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def get_lucky_number(self, day: date | None = None):
+        return await self._api.get_lucky_number(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            constituent_unit_id=self.constituent_unit_id,
+            day=day or date.today(),
+        )
+
+    async def get_messages(self):
+        if not self.message_box_key:
+            return []
+        return await self._api.get_received_messages(
+            rest_url=self.rest_url,
+            box=self.message_box_key,
+            pupil_id=self.pupil_id,
+        )
+
+    async def get_homework_all(self):
+        return await self._api.get_homework(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date(1970, 1, 1),
+            date_to=date.today(),
+        )
+
+    async def get_exams_all(self):
+        return await self._api.get_exams(
+            rest_url=self.rest_url,
+            pupil_id=self.pupil_id,
+            date_from=date(1970, 1, 1),
+            date_to=date.today(),
+        )

--- a/custom_components/vulcan/manifest.json
+++ b/custom_components/vulcan/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Antoni-Czaplicki/vulcan-for-hassio/issues",
   "quality_scale": "silver",
-  "requirements": ["vulcan-api==2.4.2"],
+  "requirements": ["pydantic==2.11.3", "cryptography==44.0.0"],
   "version": "0.17.1"
 }

--- a/custom_components/vulcan/register.py
+++ b/custom_components/vulcan/register.py
@@ -1,10 +1,19 @@
-"""Support for register Vulcan account."""
+"""Support for registering Vulcan credentials."""
 
-from vulcan import Account, Keystore
+from __future__ import annotations
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .iris.api import IrisHebeApi
+from .iris.credentials import RsaCredential
 
 
-async def register(hass, token, symbol, pin):
+async def register(hass, token: str, symbol: str, pin: str) -> RsaCredential:
     """Register integration and save credentials."""
-    keystore = await Keystore.create(device_model="Home Assistant")
-    account = await Account.register(keystore, token, symbol, pin)
-    return {"account": account, "keystore": keystore}
+
+    credential = RsaCredential.create_new(
+        device_os="Android", device_model="Home Assistant"
+    )
+    api = IrisHebeApi(credential, session=async_get_clientsession(hass))
+    await api.register_by_token(security_token=token, pin=pin, tenant=symbol)
+    return credential

--- a/custom_components/vulcan/sensor.py
+++ b/custom_components/vulcan/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from vulcan import UnauthorizedCertificateException
+from .iris import CertificateNotFoundException
 
 from . import DOMAIN, VulcanEntity
 from .const import (
@@ -73,7 +73,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         ),
                     ),
                 }
-        except UnauthorizedCertificateException:
+        except CertificateNotFoundException:
             _LOGGER.error(
                 "The certificate is not authorized, please authorize integration again."
             )


### PR DESCRIPTION
## Summary
- vendor the Iris API client and expose a thin IrisClient wrapper to replace the legacy vulcan-api usage
- rework setup, registration, and config flow to use Iris credentials and updated error handling
- refresh data fetch helpers, calendars, and sensors to consume Iris models and update dependencies

## Testing
- python -m compileall custom_components/vulcan

------
https://chatgpt.com/codex/tasks/task_e_68d9363db88c832e972d01cdb0fd0f49